### PR TITLE
Fixes the background color of the appetite label on a Pitch

### DIFF
--- a/components/Pitches.js
+++ b/components/Pitches.js
@@ -22,7 +22,7 @@ export default function Pitches({ pitches = [] }) {
                 <dl className="mt-1 flex-grow flex flex-col justify-between">
                   <dt className="sr-only">Appetite</dt>
                   <dd className="mt-3">
-                    <span className="px-2 py-1 text-teal-800 text-xs leading-4 font-medium bg-teal-100 rounded-full">{appetite(pitch)}</span>
+                    <span className="px-2 py-1 text-teal-800 text-xs leading-4 font-medium bg-cyan-200 rounded-full">{appetite(pitch)}</span>
                   </dd>
                   <dt className="sr-only">Author avatar</dt>
                   <dd className="text-gray-700 text-sm leading-5 mt-6 mb-1">


### PR DESCRIPTION
Currently, it's displayed without background color:

![](https://user-images.githubusercontent.com/242119/104309185-0fceab80-54d2-11eb-92dc-199673e7b1c5.png)

This PR makes it look like this:

![](https://user-images.githubusercontent.com/242119/104309250-2543d580-54d2-11eb-8d6e-84405e4b1f4c.png)
