### PR TITLE
feat: show the previous Cycle when there is no active one

### DIFF
--- a/components/Cycle.js
+++ b/components/Cycle.js
@@ -45,7 +45,11 @@ export default function Cycle({ visibleCycle, inCycle, previousCycle, nextCycle,
                       isPastCycle ? (
                         <span>
                           This cycle has already finished.
-                          <Link href="/"><a className="inline-flex mx-1.5 text-sm text-gray-900 font-medium hover:text-gray-600 transition ease-in-out duration-150">Go to the current cycle.</a></Link>
+                          {nextCycle ? (
+                            <Link href="/"><a className="inline-flex mx-1.5 text-sm text-gray-900 font-medium hover:text-gray-600 transition ease-in-out duration-150">Go to the current cycle.</a></Link>
+                          ) : (
+                            <a className="inline-flex mx-1.5 text-sm text-gray-900 font-medium">We're currently evaluating what's next. Please come back soon.</a>
+                          )}
                         </span>
                       ) : (
                         shouldShowPitches() ? (

--- a/components/CyclePage.js
+++ b/components/CyclePage.js
@@ -139,6 +139,7 @@ export default function CyclePage({ visibleCycle, previousCycle, nextCycle, inCy
 export async function getServerSideProps({ params = {} }) {
   const { cycle, inCycle } = getVisibleCycleDetails(params.id)
   if (!cycle) return { notFound: true }
+
   data.visibleCycle = cycle
   data.inCycle = inCycle
   
@@ -185,6 +186,13 @@ function getVisibleCycleDetails(id) {
       if (startDate <= now && endDate >= now) inCycle = true
       return c
     })
+
+    if (!cycle && data.cycles.length > 0) {
+      // If there is no active cycle, pick up the last finished one.
+      cycle = [...data.cycles].sort(function(a,b){
+        return new Date(b.due_on) - new Date(a.due_on);
+      })[0];
+    }
   }
 
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1669,11 +1669,6 @@
             "node-releases": "^1.1.67"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001164",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001164.tgz",
-          "integrity": "sha512-G+A/tkf4bu0dSp9+duNiXc7bGds35DioCyC6vgK2m/rjA4Krpy5WeZgZyfH2f0wj2kI6yAWWucyap6oOwmY1mg=="
-        },
         "electron-to-chromium": {
           "version": "1.3.613",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.613.tgz",
@@ -2028,9 +2023,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001151",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001151.tgz",
-      "integrity": "sha512-Zh3sHqskX6mHNrqUerh+fkf0N72cMxrmflzje/JyVImfpknscMnkeJrlFGJcqTmaa0iszdYptGpWMJCRQDkBVw=="
+      "version": "1.0.30001218",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001218.tgz",
+      "integrity": "sha512-0ASydOWSy3bB88FbDpJSTt+PfDwnMqrym3yRZfqG8EXSQ06OZhF+q5wgYP/EN+jJMERItNcDQUqMyNjzZ+r5+Q=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -4824,13 +4819,6 @@
             "electron-to-chromium": "^1.3.585",
             "escalade": "^3.1.1",
             "node-releases": "^1.1.65"
-          },
-          "dependencies": {
-            "caniuse-lite": {
-              "version": "1.0.30001164",
-              "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001164.tgz",
-              "integrity": "sha512-G+A/tkf4bu0dSp9+duNiXc7bGds35DioCyC6vgK2m/rjA4Krpy5WeZgZyfH2f0wj2kI6yAWWucyap6oOwmY1mg=="
-            }
           }
         },
         "electron-to-chromium": {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

This PR makes the app show the previous Cycle when there is no active one and a message `We're currently evaluating what's next. Please come back soon.` where the link to the current Cycle was before. Opened to change the copy here.

Before:
<img width="826" src="https://user-images.githubusercontent.com/1083296/116262861-2cd57480-a779-11eb-96c9-8dd39900c80a.png">

After:
<img width="1243" src="https://user-images.githubusercontent.com/1083296/116262873-2e06a180-a779-11eb-9c35-816d7f2e2966.png">
