### PR TITLE
feat: trigger AsyncAPI site deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,9 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Trigger deploy on Netlify
+    - name: Trigger shape-up site deploy on Netlify
       run: |
-        curl -X POST "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/builds" -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN"
+        curl -X POST "https://api.netlify.com/api/v1/sites/$NETLIFY_SHAPEUP_SITE_ID/builds" -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN"
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SHAPEUP_SITE_ID }}
+    - name: Trigger AsyncAPI site deploy on Netlify (Roadmap update)
+      run: |
+        curl -X POST "https://api.netlify.com/api/v1/sites/$NETLIFY_ASYNCAPI_SITE_ID/builds" -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN"
+      env:
+        NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_ASYNCAPI_SITE_ID }}


### PR DESCRIPTION
**Description**

This PR adds a new step in the deploy.yml workflow so AsyncAPI website gets also deployed, updating the [roadmap](https://asyncapi.org/roadmap) if needed.

Note that `$NETLIFY_SITE_ID` env var has been renamed to `$NETLIFY_SHAPEUP_SITE_ID`, and `$NETLIFY_ASYNCAPI_SITE_ID` has been added. **Changes on secrets should be applied** cc @derberg