### PR TITLE
fix: specify netlify site ids as plain text + fail when error when deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,15 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Trigger shape-up site deploy on Netlify
+    - name: Trigger asyncapi-shape-up site deploy on Netlify
       run: |
-        curl -X POST "https://api.netlify.com/api/v1/sites/$NETLIFY_SHAPEUP_SITE_ID/builds" -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN"
+        curl -X POST "https://api.netlify.com/api/v1/sites/asyncapi-shape-up/builds" -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" -i --fail-with-body
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SHAPEUP_SITE_ID }}
-    - name: Trigger AsyncAPI site deploy on Netlify (Roadmap update)
+    - name: Trigger asyncapi-website site deploy on Netlify (Roadmap update)
       run: |
-        curl -X POST "https://api.netlify.com/api/v1/sites/$NETLIFY_ASYNCAPI_SITE_ID/builds" -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN"
+        curl -X POST "https://api.netlify.com/api/v1/sites/asyncapi-website/builds" -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" -i --fail-with-body
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_ASYNCAPI_SITE_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
     - name: Trigger asyncapi-shape-up site deploy on Netlify
       run: |
-        curl -X POST "https://api.netlify.com/api/v1/sites/asyncapi-shape-up/builds" -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" -i --fail-with-body
+        curl -X POST "https://api.netlify.com/api/v1/sites/asyncapi-shape-up/builds" -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" -i -f
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
     - name: Trigger asyncapi-website site deploy on Netlify (Roadmap update)
       run: |
-        curl -X POST "https://api.netlify.com/api/v1/sites/asyncapi-website/builds" -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" -i --fail-with-body
+        curl -X POST "https://api.netlify.com/api/v1/sites/asyncapi-website/builds" -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" -i -f
       env:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
**Description**

This moves the netlify site ids from env vars to plain text. It also adds `-i` and `-f` args to the curl call, which allow us to see the response headers and to fail the execution in case of a >400 response code respectively.

@derberg would you mind removing the following secrets as they are not used anymore?:

- `NETLIFY_SHAPEUP_SITE_ID`
- `NETLIFY_ASYNCAPI_SITE_ID`